### PR TITLE
fix: Add Vercel rewrite configuration for routing

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a `vercel.json` configuration file to the client application. This file includes a rewrite rule that directs all traffic to `index.html`, which is necessary to fix 404 errors when directly accessing sub-pages (e.g., `/login`, `/dashboard`) in a single-page application (SPA) hosted on Vercel.