### PR TITLE
fix: Correct API request path for production

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-    baseURL: process.env.REACT_APP_API_URL || '/api'
+    baseURL: `${process.env.REACT_APP_API_URL || ''}/api`
 });
 
 // Add a request interceptor to include the token from localStorage


### PR DESCRIPTION
This commit fixes a bug where the frontend was making API calls to the wrong path in the production environment. The `baseURL` for axios has been updated to correctly prepend the `/api` prefix to all requests, resolving the 404 errors on login and signup.